### PR TITLE
feat: make user-agent optional in the NewWithConfig

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -63,6 +63,7 @@ func New(logger *slog.Logger) gin.HandlerFunc {
 		ClientErrorLevel: slog.LevelWarn,
 		ServerErrorLevel: slog.LevelError,
 
+		WithUserAgent:      false,
 		WithRequestID:      true,
 		WithRequestBody:    false,
 		WithRequestHeader:  false,
@@ -70,8 +71,7 @@ func New(logger *slog.Logger) gin.HandlerFunc {
 		WithResponseHeader: false,
 		WithSpanID:         false,
 		WithTraceID:        false,
-
-		Filters: []Filter{},
+		Filters:            []Filter{},
 	})
 }
 
@@ -85,6 +85,7 @@ func NewWithFilters(logger *slog.Logger, filters ...Filter) gin.HandlerFunc {
 		ClientErrorLevel: slog.LevelWarn,
 		ServerErrorLevel: slog.LevelError,
 
+		WithUserAgent:      false,
 		WithRequestID:      true,
 		WithRequestBody:    false,
 		WithRequestHeader:  false,

--- a/middleware.go
+++ b/middleware.go
@@ -41,6 +41,7 @@ type Config struct {
 	ClientErrorLevel slog.Level
 	ServerErrorLevel slog.Level
 
+	WithUserAgent      bool
 	WithRequestID      bool
 	WithRequestBody    bool
 	WithRequestHeader  bool
@@ -140,8 +141,11 @@ func NewWithConfig(logger *slog.Logger, config Config) gin.HandlerFunc {
 			slog.String("route", c.FullPath()),
 			slog.String("ip", c.ClientIP()),
 			slog.Duration("latency", latency),
-			slog.String("user-agent", c.Request.UserAgent()),
 			slog.Time("time", end),
+		}
+
+		if config.WithUserAgent {
+			attributes = append(attributes, slog.String("user-agent", c.Request.UserAgent()))
 		}
 
 		if config.WithRequestID {


### PR DESCRIPTION
Hi,
I think it's a good idea to make the user-agent optional (it's not activated by default in the gin logger), because it makes the logs heavier, especially in dev where you don't really need to retrieve it.

I've made the arbitrary choice of setting it to false by default, but this means I'll have to notify you in the release note because it's a breaking change. Wouldn't leaving it at true by default be a better idea?
I'm not sure, but I'm open to your suggestion.