### PR TITLE
fix: use existing x-header-id header if set

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -15,6 +15,8 @@ import (
 const (
 	customAttributesCtxKey = "slog-gin.custom-attributes"
 	requestIDCtx           = "slog-gin.request-id"
+	// Formatted with http.CanonicalHeaderKey
+	requestIDHeaderKey = "X-Request-Id"
 )
 
 var (
@@ -109,10 +111,13 @@ func NewWithConfig(logger *slog.Logger, config Config) gin.HandlerFunc {
 			params[p.Key] = p.Value
 		}
 
-		requestID := uuid.New().String()
+		requestID := c.GetHeader(requestIDHeaderKey)
 		if config.WithRequestID {
+			if requestID == "" {
+				requestID = uuid.New().String()
+				c.Header(requestIDHeaderKey, requestID)
+			}
 			c.Set(requestIDCtx, requestID)
-			c.Header("X-Request-ID", requestID)
 		}
 
 		// dump request body


### PR DESCRIPTION
Currently, if `config.WithRequestID == true`, a random request ID is generated, added to the context, and set in the request headers (`x-header-id`).

The `x-header-id` may already exist (ex: using envoy/istio in a kubernetes cluster), so we should use that if it's available instead of clobbering its value with our own.