### PR TITLE
Fix: Set status filter logic straight

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -73,22 +73,38 @@ func AcceptStatusGreaterThan(status int) Filter {
 	}
 }
 
-func IgnoreStatusLessThan(status int) Filter {
-	return func(c *gin.Context) bool {
-		return c.Writer.Status() < status
-	}
-}
-
 func AcceptStatusGreaterThanOrEqual(status int) Filter {
 	return func(c *gin.Context) bool {
 		return c.Writer.Status() >= status
 	}
 }
 
-func IgnoreStatusLessThanOrEqual(status int) Filter {
+func AcceptStatusLessThan(status int) Filter {
+	return func(c *gin.Context) bool {
+		return c.Writer.Status() < status
+	}
+}
+
+func AcceptStatusLessThanOrEqual(status int) Filter {
 	return func(c *gin.Context) bool {
 		return c.Writer.Status() <= status
 	}
+}
+
+func IgnoreStatusGreaterThan(status int) Filter {
+	return AcceptStatusLessThanOrEqual(int)
+}
+
+func IgnoreStatusGreaterThanOrEqual(status int) Filter {
+	return AcceptStatusLessThan(int)
+}
+
+func IgnoreStatusLessThan(status int) Filter {
+	return AcceptStatusGreaterThanOrEqual(int)
+}
+
+func IgnoreStatusLessThanOrEqual(status int) Filter {
+	return AcceptStatusGreaterThan(int)
 }
 
 // Path


### PR DESCRIPTION
Earlier, the `Ignore*` status filters' logical comparisons were reversed, resulting in request/responses of lower status code being logged despite having a filter in place for it.

For example, `IgnoreStatusLessThan()` checked if the responses' status was less than the argument for the function like so: `c.Writer.Status() < status`, when it actually was supposed to be `c.Writer.Status() >= status`.

In this patch I added the missing upper and lower bound `Accept/Ignore` cases, and since the ignore cases are mirror images of the accept cases, I just call the corresponding `Accept` functions instead of duplicating the logic conditions.